### PR TITLE
Fixes for version 2.6.1

### DIFF
--- a/ChangeLogWIP.html
+++ b/ChangeLogWIP.html
@@ -4,6 +4,10 @@
 <h2>Version 2.6.1</h2>
 <ul>
 	<li>Fix: Autoupdater should now open on top of the main application</li>
+	<li>Fix: Driver position animation should now be more fluent and less cpu intensive</li>
+	<li>Fix: Lapped/Laping coloring restoring on all timing columns </li>
+	<li>Fix: Delta bar sometimes didn't detect best lap change correctly </li>
+	<li>Fix: Pace time sometimes lagging behind by one lap</li>
 </ul>
 <h2>Version 2.6.0</h2>
 <ul>

--- a/Timing/Presentation/Controls/TimingGridControl/TimingGrid.xaml
+++ b/Timing/Presentation/Controls/TimingGridControl/TimingGrid.xaml
@@ -10,11 +10,16 @@
         <Setter Property="Foreground" Value="{StaticResource LightGrey01Brush}" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding IsLastLapBestLap}" Value="True">
-                <Setter Property="Foreground" Value="White" />
                 <Setter Property="Background" Value="{StaticResource Green01Brush}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding IsLastLapBestSessionLap}" Value="True">
                 <Setter Property="Background" Value="{StaticResource PurpleTimingBrush}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding IsLapped, Mode=OneWay}" Value="True">
+                <Setter Property="Foreground" Value="{StaticResource LightBlueBrush}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding IsLapping, Mode=OneWay}" Value="True">
+                <Setter Property="Foreground" Value="{StaticResource DarkRed01Brush}" />
             </DataTrigger>
         </Style.Triggers>
     </Style>

--- a/Timing/SessionTiming/Drivers/ViewModel/CombinedLapPortionComparatorsVM.cs
+++ b/Timing/SessionTiming/Drivers/ViewModel/CombinedLapPortionComparatorsVM.cs
@@ -43,6 +43,10 @@
                 }
 
                 _playerLap = value;
+                if (_playerLap?.Driver != null)
+                {
+                    _playerLap.Driver.LapCompleted += DriverOnLapCompleted;
+                }
                 OnPropertyChanged();
                 RecreatePlayerLapToPrevious();
                 RecreatePlayerLapToPlayerBest();

--- a/Timing/SessionTiming/Drivers/ViewModel/DriverTiming.cs
+++ b/Timing/SessionTiming/Drivers/ViewModel/DriverTiming.cs
@@ -135,20 +135,7 @@
         {
             get
             {
-                if (_lapsInfo.Count < 2)
-                {
-                    return null;
-                }
-
-                for (int i = _lapsInfo.Count - 2; i >= 0; i--)
-                {
-                    if (Session.RetrieveAlsoInvalidLaps || _lapsInfo[i].Valid)
-                    {
-                        return _lapsInfo[i];
-                    }
-                }
-
-                return null;
+                return _lapsInfo.LastOrDefault(x => x.Completed && (x.Valid || Session.RetrieveAlsoInvalidLaps));
             }
         }
 

--- a/WindowsControls/WPF/DriverPosition/DriverPositionControl.cs
+++ b/WindowsControls/WPF/DriverPosition/DriverPositionControl.cs
@@ -88,7 +88,7 @@
         {
             if (Animate)
             {
-                _translateTransform.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(Y, _animationTime), HandoffBehavior.Compose);
+                _translateTransform.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(Y, _animationTime), HandoffBehavior.SnapshotAndReplace);
             }
             else
             {
@@ -100,7 +100,7 @@
         {
             if (Animate)
             {
-                _translateTransform.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(X, _animationTime), HandoffBehavior.Compose);
+                _translateTransform.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(X, _animationTime), HandoffBehavior.SnapshotAndReplace);
 
             }
             else


### PR DESCRIPTION
Fix: Autoupdater should now open on top of the main application
Fix: Driver position animation should now be more fluent and less cpu intensive
Fix: Lapped/Laping coloring restoring on all timing columns
Fix: Delta bar sometimes didn't detect best lap change correctly
Fix: Pace time sometimes lagging behind by one lap